### PR TITLE
M1: shared time constants

### DIFF
--- a/src/api/handlers/trueup.rs
+++ b/src/api/handlers/trueup.rs
@@ -1,5 +1,6 @@
 use crate::api::handlers::energy::parse_iso_or;
 use crate::api::server::AppState;
+use crate::constants::DAY_SECS;
 use crate::error::{ApiError, AppError, TouError};
 use crate::storage::energy_window::FormulaFilter;
 use crate::storage::models::TrueUpEstimate;
@@ -73,7 +74,7 @@ pub async fn get_estimate(
 
     // energy_window::query_range uses exclusive end (`window_start < ?`); add one day so the
     // user-supplied UTC midnight date is inclusive. Callers must pass `end` as a UTC instant.
-    let period_end = period_end + 86_400;
+    let period_end = period_end + DAY_SECS;
 
     let schedule = tou_schedule::query_latest(&state.pool, &state.tou_rate_label)
         .await?

--- a/src/collector/scheduler.rs
+++ b/src/collector/scheduler.rs
@@ -7,6 +7,7 @@ use crate::collector::gateway_client::GatewayClient;
 use crate::collector::window_aggregator::{
     CURRENT_FORMULA_VERSION, CumulativeReading, compute_delta, window_boundary,
 };
+use crate::constants::DAY_SECS;
 use crate::storage::{
     boundary_snapshot, config_store, energy_window as ew_store, inverter_snapshot as inv_store,
     phase_reading as phase_store, power_sample as ps_store,
@@ -377,13 +378,13 @@ impl Scheduler {
                 last_reading = Some(curr);
             }
 
-            if now - last_retention_check >= 86400 {
-                let cutoff = now - (self.retention_days as i64 * 86400);
+            if now - last_retention_check >= DAY_SECS {
+                let cutoff = now - (self.retention_days as i64 * DAY_SECS);
                 match ps_store::delete_before(&self.pool, cutoff).await {
                     Ok(deleted) => info!(event = "power_sample_retention", deleted, cutoff),
                     Err(e) => error!(event = "power_sample_retention_error", error = %e),
                 }
-                let phase_cutoff = now - (self.phase_retention_days as i64 * 86400);
+                let phase_cutoff = now - (self.phase_retention_days as i64 * DAY_SECS);
                 match phase_store::delete_before(&self.pool, phase_cutoff).await {
                     Ok(deleted) => info!(
                         event = "phase_reading_retention",

--- a/src/collector/window_aggregator.rs
+++ b/src/collector/window_aggregator.rs
@@ -1,6 +1,6 @@
+pub use crate::constants::WINDOW_SECS;
 use crate::storage::models::EnergyWindow;
 
-pub const WINDOW_SECS: i64 = 15 * 60;
 pub const CURRENT_FORMULA_VERSION: i32 = 1;
 
 #[derive(Debug, Clone)]

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,0 +1,19 @@
+/// Duration of one energy-collection window in seconds (15 minutes).
+/// See CLAUDE.md "Cumulative-to-delta conversion" and `collector/window_aggregator.rs`.
+pub const WINDOW_SECS: i64 = 15 * 60;
+
+/// Inverter offline threshold in seconds (20 minutes).
+/// See CLAUDE.md "Inverter online threshold": `OFFLINE_THRESHOLD_SECS = 1200`.
+pub const INVERTER_OFFLINE_THRESHOLD_SECS: i64 = 20 * 60;
+
+/// TOU refresh interval in seconds (7 days).
+/// See CLAUDE.md "TOU schedule lifecycle" — `tou/refresh.rs` re-fetches every 7 days.
+pub const TOU_REFRESH_INTERVAL_SECS: i64 = 7 * 24 * 3600;
+
+/// TOU stale alarm threshold in seconds (90 days).
+/// See CLAUDE.md "TOU schedule lifecycle" — health/probe flags schedule stale after 90 days.
+pub const TOU_STALE_THRESHOLD_SECS: i64 = 90 * 24 * 3600;
+
+/// Seconds in one calendar day (86 400).
+/// Used for end-bound normalization in `api/handlers/trueup.rs::get_estimate`.
+pub const DAY_SECS: i64 = 24 * 3600;

--- a/src/inverter/snapshot.rs
+++ b/src/inverter/snapshot.rs
@@ -1,8 +1,6 @@
+use crate::constants::INVERTER_OFFLINE_THRESHOLD_SECS;
 use crate::storage::models::MicroinverterSnapshot;
 use serde::Deserialize;
-
-// Inverter is considered offline if last report is older than 20 minutes
-const OFFLINE_THRESHOLD_SECS: i64 = 20 * 60;
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -20,7 +18,7 @@ pub fn parse_snapshots(
     reports
         .into_iter()
         .map(|r| {
-            let is_online = (now - r.last_report_date) < OFFLINE_THRESHOLD_SECS;
+            let is_online = (now - r.last_report_date) < INVERTER_OFFLINE_THRESHOLD_SECS;
             MicroinverterSnapshot {
                 id: 0,
                 window_start,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@ pub mod api;
 pub mod auth;
 pub mod collector;
 pub mod config;
+pub mod constants;
 pub mod error;
 pub mod inverter;
 pub mod storage;

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ mod api;
 mod auth;
 mod collector;
 mod config;
+mod constants;
 mod error;
 mod inverter;
 mod storage;

--- a/src/tou/probe.rs
+++ b/src/tou/probe.rs
@@ -1,14 +1,17 @@
+use crate::constants::{DAY_SECS, TOU_STALE_THRESHOLD_SECS};
 use crate::storage::tou_schedule;
 use sqlx::SqlitePool;
 
-pub(crate) const STALE_THRESHOLD_SECS: i64 = 90 * 24 * 3600;
+// Alias kept so existing tests (which use `use super::*`) continue to compile unchanged.
+#[allow(unused_imports)]
+pub(crate) use crate::constants::TOU_STALE_THRESHOLD_SECS as STALE_THRESHOLD_SECS;
 
 pub async fn probe_tou_schedule(pool: &SqlitePool, rate_label: &str) {
     let now = crate::util::unix_now();
     match tou_schedule::query_latest(pool, rate_label).await {
         Ok(Some(schedule)) => {
-            let age_days = (now - schedule.fetched_at) / (24 * 3600);
-            if now - schedule.fetched_at > STALE_THRESHOLD_SECS {
+            let age_days = (now - schedule.fetched_at) / DAY_SECS;
+            if now - schedule.fetched_at > TOU_STALE_THRESHOLD_SECS {
                 tracing::warn!(event = "tou_schedule_stale", age_days = age_days);
             } else {
                 tracing::info!(event = "tou_schedule_ok", age_days = age_days);

--- a/src/tou/refresh.rs
+++ b/src/tou/refresh.rs
@@ -1,10 +1,9 @@
+use crate::constants::TOU_REFRESH_INTERVAL_SECS;
 use crate::error::AppError;
 use crate::storage::tou_schedule;
 use crate::tou::openei_client::OpenEiClient;
 use sqlx::SqlitePool;
 use std::time::Duration;
-
-const REFRESH_TRIGGER_SECS: i64 = 7 * 24 * 3600;
 
 pub async fn run_tou_refresh_loop(
     pool: SqlitePool,
@@ -24,7 +23,7 @@ pub async fn run_tou_refresh_loop(
     }
 
     loop {
-        tokio::time::sleep(Duration::from_secs(7 * 24 * 3600)).await;
+        tokio::time::sleep(Duration::from_secs(TOU_REFRESH_INTERVAL_SECS as u64)).await;
         if let Err(e) = do_refresh(
             &pool,
             &api_key,
@@ -42,7 +41,7 @@ pub async fn run_tou_refresh_loop(
 async fn needs_refresh_now(pool: &SqlitePool, rate_label: &str) -> bool {
     let now = crate::util::unix_now();
     match tou_schedule::query_latest(pool, rate_label).await {
-        Ok(Some(s)) => (now - s.fetched_at) > REFRESH_TRIGGER_SECS,
+        Ok(Some(s)) => (now - s.fetched_at) > TOU_REFRESH_INTERVAL_SECS,
         Ok(None) => true,
         Err(_) => false,
     }

--- a/tests/unit.rs
+++ b/tests/unit.rs
@@ -1,5 +1,8 @@
 mod common;
 
+#[path = "unit/constants_test.rs"]
+mod constants_test;
+
 #[path = "unit/token_manager_test.rs"]
 mod token_manager_test;
 

--- a/tests/unit/constants_test.rs
+++ b/tests/unit/constants_test.rs
@@ -1,0 +1,29 @@
+use enphase_bridge::constants::{
+    DAY_SECS, INVERTER_OFFLINE_THRESHOLD_SECS, TOU_REFRESH_INTERVAL_SECS, TOU_STALE_THRESHOLD_SECS,
+    WINDOW_SECS,
+};
+
+#[test]
+fn window_secs_is_900() {
+    assert_eq!(WINDOW_SECS, 900);
+}
+
+#[test]
+fn inverter_offline_threshold_is_1200() {
+    assert_eq!(INVERTER_OFFLINE_THRESHOLD_SECS, 1200);
+}
+
+#[test]
+fn tou_refresh_interval_is_7_days() {
+    assert_eq!(TOU_REFRESH_INTERVAL_SECS, 7 * 86_400);
+}
+
+#[test]
+fn tou_stale_threshold_is_90_days() {
+    assert_eq!(TOU_STALE_THRESHOLD_SECS, 90 * 86_400);
+}
+
+#[test]
+fn day_secs_is_86400() {
+    assert_eq!(DAY_SECS, 86_400);
+}


### PR DESCRIPTION
## Score delta

| milestone | production_score |
|-----------|-----------------|
| baseline  | 36              |
| M1 (this PR) | 36           |

M1 is the smallest structural win — it unblocks downstream milestones (M2 scheduler split) which carry the larger nesting/long-file reductions.

## What changed

- Added `src/constants.rs` with five `pub const` values, each with a doc comment citing the CLAUDE.md or spec reference:
  - `WINDOW_SECS = 900` — 15-minute energy window
  - `INVERTER_OFFLINE_THRESHOLD_SECS = 1200` — 20-minute offline threshold
  - `TOU_REFRESH_INTERVAL_SECS = 7 * 86_400` — TOU eager-refresh cadence
  - `TOU_STALE_THRESHOLD_SECS = 90 * 86_400` — TOU health alarm threshold
  - `DAY_SECS = 86_400` — end-bound normalization unit
- Declared `pub mod constants` in `src/lib.rs` and `mod constants` in `src/main.rs`
- Replaced matching inline literals in: `inverter/snapshot.rs`, `tou/refresh.rs`, `tou/probe.rs`, `api/handlers/trueup.rs`, `collector/scheduler.rs`, `collector/window_aggregator.rs`
- Added `tests/unit/constants_test.rs` (5 assertions, one per constant) — TDD RED→GREEN

## No behavior change

All 68 existing tests pass. No tracing event field name was added, removed, or renamed — confirmed by grepping `event = "..."` strings before and after; the diff is empty.

## Test plan

- [ ] `cargo test` — all 68 tests pass
- [ ] `cargo clippy --all-targets -- -D warnings` — clean
- [ ] `cargo fmt --check` — clean
- [ ] Log event names before vs. after: no diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)